### PR TITLE
Suggested author contributions ordering.

### DIFF
--- a/paper/dox_paper.tex
+++ b/paper/dox_paper.tex
@@ -313,13 +313,11 @@ We gratefully acknowledge Bryan Schneider for providing GWAS summary statistics.
 
 \section*{Author Contributions}
 
-YG and CO conceived the project.
-DAK performed data analysis, algorithm development and statistics, and prepared the manuscript. 
-KMP and CB performed the experiments and sequencing. 
-JB performed data analysis and QC. 
-KMP performed sequencing. 
-CO and YG provided source material.
+YG and CO conceived the project and provided source material.
+CB performed the experiments with assistance from KMP.
+DAK analyzed the data with assistance from JDB.
 JKP, CO and YG supervised the project.
+DAK wrote the paper with input from CB, YG, JKP, CO, and JDB.
 
 \section*{[References at the end]}
 \newpage


### PR DESCRIPTION
I usually see author contribution sections organized not by author order, but by order of the action, i.e. project conception is first and writing the paper is last. I don't feel strongly about this, so feel free to close this or heavily edit post-merge.